### PR TITLE
Fixed comment about minimum version required on index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
  */
 
 /**
- * Version must be greater than 5.3.3.
+ * Version must be greater than 5.4.16.
  *
  * Note, we use `dirname(__FILE__)` instead of `__DIR__`. The latter was introduced "only" in
  * PHP 5.3, and we need to be able to show the notice to the poor souls who are still on PHP 5.2.


### PR DESCRIPTION
Just a quick fix on index.php, the file mentioned on its comments that the minimum version required for bolt was 5.3.3